### PR TITLE
Fixes/driftignore related fixes

### DIFF
--- a/deploy/driftctl_exporter/templates/cronjob.yaml
+++ b/deploy/driftctl_exporter/templates/cronjob.yaml
@@ -10,17 +10,18 @@ metadata:
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    checksum/driftignore: {{ include (print $.Template.BasePath "/driftignore.yaml") . | sha256sum }}
 spec:
   jobTemplate:
     metadata:
-      creationTimestamp: null
-      name: wtf
+      name: {{ .Release.Name }}
     spec:
       template:
         metadata:
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
             checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+            checksum/driftignore: {{ include (print $.Template.BasePath "/driftignore.yaml") . | sha256sum }}
         spec:
           containers:
             - name: {{ .Release.Name }}-initial-scan
@@ -41,6 +42,15 @@ spec:
               command:
                 - python
                 - scan.py
+              volumeMounts:
+                - name: driftignore
+                  mountPath: /usr/src/.driftignore
+                  subPath: .driftignore
+                  readOnly: true
+          volumes:
+            - name: driftignore
+              configMap:
+                name: {{ .Release.Name }}-driftignore
           restartPolicy: OnFailure
   schedule: {{ .Values.cronjob.schedule }}
 status: {}

--- a/deploy/driftctl_exporter/templates/deployment.yaml
+++ b/deploy/driftctl_exporter/templates/deployment.yaml
@@ -63,6 +63,7 @@ spec:
           volumeMounts:
             - name: driftignore
               mountPath: /usr/src/.driftignore
+              subPath: .driftignore
               readOnly: true
       containers:
         - name: {{ .Release.Name }}

--- a/deploy/driftctl_exporter/templates/deployment.yaml
+++ b/deploy/driftctl_exporter/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    checksum/driftignore: {{ include (print $.Template.BasePath "/driftignore.yaml") . | sha256sum }}
 
 spec:
   {{ if .Values.deployment.strategy }}
@@ -26,6 +27,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/driftignore: {{ include (print $.Template.BasePath "/driftignore.yaml") . | sha256sum }}
       labels:
         {{- include "pod-with-service-ingress.selectorLabels" . | nindent 8 }}
         {{- with .Values.deployment.labels }}

--- a/deploy/driftctl_exporter/tests/deployment_test.yaml
+++ b/deploy/driftctl_exporter/tests/deployment_test.yaml
@@ -3,6 +3,7 @@ templates:
   - deployment.yaml
   - configmap.yaml
   - secret.yaml
+  - driftignore.yaml
 
 arrange: &default-release
   release:


### PR DESCRIPTION
## Scenario

This PR fixes the following  bugs related to driftignore usage:

 * The "initial-scan" initContainer wasn't using the driftignore file during the container startup;
 * The `scan` job wasn't using driftignore file during its execution;
 * Changes on driftignore wasn't triggering pod recreation.