### PR TITLE
fix: Update per item metrics description to match metrics.

### DIFF
--- a/src/exporter/metrics.py
+++ b/src/exporter/metrics.py
@@ -9,19 +9,19 @@ def get_metrics():
     total_managed = Gauge('total_managed', 'Number of resources fully managed by Iac.')
     coverage = Gauge('coverage', 'Relation between `total_managed` and `total_resources`.')
     managed_items_count_by_type = Gauge('managed_items_count_by_type',
-                                        'Number of resources by type fully managed by Iac. '
+                                        'Resources by type fully managed by Iac. '
                                         'Eg: number of `aws_s3_bucket` and so on.',
                                         labelnames=['resource'])
     unmanaged_items_count_by_type = Gauge('unmanaged_items_count_by_type',
-                                          'Number of resources by type fully managed by Iac. '
+                                          'Resources present on cloud provider but no declared on Iac.'
                                           'Eg: number of `aws_iam_user` and so on.',
                                           labelnames=['resource'])
     missing_items_count_by_type = Gauge('missing_items_count_by_type',
-                                        'Number of resources by type fully managed by Iac. '
+                                        'Resources declared on Iac but missing from the cloud provider.'
                                         'Eg: number of `aws_sqs_queue` and so on.',
                                         labelnames=['resource'])
     changed_items_count_by_type = Gauge('changed_items_count_by_type',
-                                        'Number of resources that are declared on Iac but were changed externally, '
+                                        'Resources that are declared on Iac but were changed externally.'
                                         'by resource type. Eg: number of `aws_dynamodb_table` and so on.',
                                         labelnames=['resource'])
 


### PR DESCRIPTION
## Scenario

Some per-item metrics aren't updated with its respective description, leading to some confusion during metric reading by humans.

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/640897/163048645-3b2ab878-693d-4efc-9d58-6a047bb4aac3.png">
